### PR TITLE
Add inmemory broker/backend and fix race conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _testmain.go
 *.pyc
 
 coverage.out
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,5 @@ before_install:
 script:
     - $HOME/gopath/bin/goveralls -service=travis-ci
 services:
-    - redis
+    - redis-server
     - rabbitmq

--- a/amqp_broker.go
+++ b/amqp_broker.go
@@ -157,13 +157,17 @@ func (b *AMQPCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
 
 // GetTaskMessage retrieves task message from AMQP queue
 func (b *AMQPCeleryBroker) GetTaskMessage() (*TaskMessage, error) {
-	delivery := <-b.consumingChannel
-	delivery.Ack(false)
-	var taskMessage TaskMessage
-	if err := json.Unmarshal(delivery.Body, &taskMessage); err != nil {
-		return nil, err
+	select {
+	case delivery := <-b.consumingChannel:
+		delivery.Ack(false)
+		var taskMessage TaskMessage
+		if err := json.Unmarshal(delivery.Body, &taskMessage); err != nil {
+			return nil, err
+		}
+		return &taskMessage, nil
+	default:
+		return nil, nil
 	}
-	return &taskMessage, nil
 }
 
 // CreateExchange declares AMQP exchange with stored configuration

--- a/backend_test.go
+++ b/backend_test.go
@@ -12,6 +12,7 @@ func getBackends() []CeleryBackend {
 	return []CeleryBackend{
 		NewRedisCeleryBackend("redis://localhost:6379"),
 		NewAMQPCeleryBackend("amqp://"),
+		NewInMemoryBackend(),
 	}
 }
 

--- a/broker_test.go
+++ b/broker_test.go
@@ -23,6 +23,7 @@ func getBrokers() []CeleryBroker {
 	return []CeleryBroker{
 		NewRedisCeleryBroker("redis://localhost:6379"),
 		//NewAMQPCeleryBroker("amqp://"),
+		NewInMemoryBroker(),
 	}
 }
 

--- a/example/worker/main.go
+++ b/example/worker/main.go
@@ -64,8 +64,8 @@ func main() {
 	celeryClient.Register("worker.add", add)
 	celeryClient.Register("worker.add_reflect", &AddTask{})
 
-	// Start Worker - blocking method
-	go celeryClient.StartWorker()
+	// Start Worker - non blocking method
+	celeryClient.StartWorker()
 	// Wait 30 seconds and stop all workers
 	time.Sleep(30 * time.Second)
 	celeryClient.StopWorker()

--- a/inmemory_backend.go
+++ b/inmemory_backend.go
@@ -1,0 +1,35 @@
+package gocelery
+
+import (
+	"errors"
+	"sync"
+)
+
+type InMemoryBackend struct {
+	ResultStore map[string]*ResultMessage
+	lock sync.RWMutex
+}
+
+func NewInMemoryBackend() *InMemoryBackend {
+	return &InMemoryBackend{make(map[string]*ResultMessage), sync.RWMutex{}}
+}
+
+func (b *InMemoryBackend) GetResult(taskID string) (*ResultMessage, error) {
+	b.lock.RLock()
+	defer b.lock.RUnlock()
+	if res, ok := b.ResultStore[taskID]; ok {
+		return res, nil
+	}
+	return nil, errors.New("task does not exist")
+}
+
+func (b *InMemoryBackend) SetResult(taskID string, result *ResultMessage) error {
+	b.lock.Lock()
+	b.ResultStore[taskID] = result
+	b.lock.Unlock()
+	return nil
+}
+
+func (b *InMemoryBackend) Clear() {
+	b.ResultStore = make(map[string]*ResultMessage)
+}

--- a/inmemory_broker.go
+++ b/inmemory_broker.go
@@ -1,0 +1,37 @@
+package gocelery
+
+import "sync"
+
+type InMemoryBroker struct {
+	taskQueue []*TaskMessage
+	lock sync.RWMutex
+}
+
+func NewInMemoryBroker() *InMemoryBroker {
+	return &InMemoryBroker{make([]*TaskMessage, 0), sync.RWMutex{}}
+}
+
+func (b *InMemoryBroker) SendCeleryMessage(m *CeleryMessage) error {
+	// this could be a bit too inefficient, for we can do sharding or use sync.Map later
+	b.lock.Lock()
+	b.taskQueue = append(b.taskQueue, m.GetTaskMessage())
+	b.lock.Unlock()
+	return nil
+}
+
+func (b *InMemoryBroker) GetTaskMessage() (t *TaskMessage, e error) {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	if len(b.taskQueue) == 0 {
+		return nil, nil
+	}
+	t, b.taskQueue = b.taskQueue[0], b.taskQueue[1:]
+	return t, nil
+}
+
+func (b *InMemoryBroker) Clear(m *CeleryMessage) error {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.taskQueue = make([]*TaskMessage, 0)
+	return nil
+}

--- a/worker.go
+++ b/worker.go
@@ -5,9 +5,10 @@ import (
 	"log"
 	"reflect"
 	"sync"
-)
+	)
 
-// CeleryWorker represents distributed task worker
+// CeleryWorker represents distributed task worker.
+// Not thread safe. Shouldn't be used from within multiple go routines.
 type CeleryWorker struct {
 	broker          CeleryBroker
 	backend         CeleryBackend
@@ -31,7 +32,7 @@ func NewCeleryWorker(broker CeleryBroker, backend CeleryBackend, numWorkers int)
 // StartWorker starts celery worker
 func (w *CeleryWorker) StartWorker() {
 
-	w.stopChannel = make(chan struct{}, 1)
+	w.stopChannel = make(chan struct{})
 	w.workWG.Add(w.numWorkers)
 
 	for i := 0; i < w.numWorkers; i++ {

--- a/worker_test.go
+++ b/worker_test.go
@@ -1,6 +1,8 @@
 package gocelery
 
 import (
+	"errors"
+	"fmt"
 	"math/rand"
 	"testing"
 	"time"
@@ -11,12 +13,27 @@ func add(a int, b int) int {
 	return a + b
 }
 
-// newCeleryWorker creates celery worker
+// newCeleryWorker creates redis celery worker
 func newCeleryWorker(numWorkers int) *CeleryWorker {
 	broker := NewRedisCeleryBroker("redis://localhost:6379")
 	backend := NewRedisCeleryBackend("redis://localhost:6379")
 	celeryWorker := NewCeleryWorker(broker, backend, numWorkers)
 	return celeryWorker
+}
+
+// newCeleryWorker creates inmemory celery worker
+func newInMemoryCeleryWorker(numWorkers int) *CeleryWorker {
+	broker := NewInMemoryBroker()
+	backend := NewInMemoryBackend()
+	celeryWorker := NewCeleryWorker(broker, backend, numWorkers)
+	return celeryWorker
+}
+
+func getWorkers(numWorkers int) []*CeleryWorker {
+	return []*CeleryWorker{
+		newCeleryWorker(numWorkers),
+		newInMemoryCeleryWorker(numWorkers),
+	}
 }
 
 // registerTask registers add test task
@@ -27,28 +44,41 @@ func registerTask(celeryWorker *CeleryWorker) string {
 	return taskName
 }
 
-func TestRegisterTask(t *testing.T) {
-	celeryWorker := newCeleryWorker(1)
-	taskName := registerTask(celeryWorker)
-	receivedTask := celeryWorker.GetTask(taskName)
-	if receivedTask == nil {
-		t.Errorf("failed to retrieve task")
+func runTestForEachWorker(testFunc func(celeryWorker *CeleryWorker, numWorkers int) error, numWorkers int, t *testing.T) {
+	for _, worker := range getWorkers(numWorkers) {
+		err := testFunc(worker, numWorkers)
+		if err != nil {
+			t.Error(err)
+		}
 	}
 }
 
-func TestRunTask(t *testing.T) {
-	celeryWorker := newCeleryWorker(1)
-	taskName := registerTask(celeryWorker)
+func TestRegisterTask(t *testing.T) {
+	runTestForEachWorker(registerTaskTest, 1, t)
+}
 
+func registerTaskTest(celeryWorker *CeleryWorker, numWorkers int) error {
+	taskName := registerTask(celeryWorker)
+	receivedTask := celeryWorker.GetTask(taskName)
+	if receivedTask == nil {
+		return errors.New("failed to retrieve task")
+	}
+	return nil
+}
+
+func TestRunTask(t *testing.T) {
+	runTestForEachWorker(runTaskTest, 1, t)
+}
+
+func runTaskTest(celeryWorker *CeleryWorker, numWorkers int) error {
+	taskName := registerTask(celeryWorker)
 	// prepare args
 	args := []interface{}{
 		rand.Int(),
 		rand.Int(),
 	}
-
 	// Run task normally
 	res := add(args[0].(int), args[1].(int))
-
 	// construct task message
 	taskMessage := &TaskMessage{
 		ID:      generateUUID(),
@@ -60,31 +90,38 @@ func TestRunTask(t *testing.T) {
 	}
 	resultMsg, err := celeryWorker.RunTask(taskMessage)
 	if err != nil {
-		t.Errorf("failed to run celery task %v: %v", taskMessage, err)
+		return errors.New(fmt.Sprintf("failed to run celery task %v: %v", taskMessage, err))
 	}
-
 	reflectRes := resultMsg.Result.(int64)
-
 	// check result
 	if int64(res) != reflectRes {
-		t.Errorf("reflect result %v is different from normal result %v", reflectRes, res)
+		return errors.New(fmt.Sprintf("reflect result %v is different from normal result %v", reflectRes, res))
 	}
+	return nil
 }
 
 func TestNumWorkers(t *testing.T) {
 	numWorkers := rand.Intn(10)
-	celeryWorker := newCeleryWorker(numWorkers)
+	runTestForEachWorker(numWorkersTest, numWorkers, t)
+}
+
+func numWorkersTest(celeryWorker *CeleryWorker, numWorkers int) error {
 	celeryNumWorkers := celeryWorker.GetNumWorkers()
 	if numWorkers != celeryNumWorkers {
-		t.Errorf("number of workers are different: %d vs %d", numWorkers, celeryNumWorkers)
+		return errors.New(fmt.Sprintf("number of workers are different: %d vs %d", numWorkers, celeryNumWorkers))
 	}
+	return nil
 }
 
 func TestStartStop(t *testing.T) {
 	numWorkers := rand.Intn(10)
-	celeryWorker := newCeleryWorker(numWorkers)
+	runTestForEachWorker(startStopTest, numWorkers, t)
+}
+
+func startStopTest(celeryWorker *CeleryWorker, numWorkers int) error {
 	_ = registerTask(celeryWorker)
-	go celeryWorker.StartWorker()
+	celeryWorker.StartWorker()
 	time.Sleep(100 * time.Millisecond)
 	celeryWorker.StopWorker()
+	return nil
 }


### PR DESCRIPTION
Hi,

gocelery is a nice library, very useful. Since we plan to use it for a soon to be open sourced project, I want to make some updates to the core library if you approve.
This first PR adds support for an in memory broker/backend to enable testing without any external queue server dependancies.

I also refactored the tests a little bit so that the tests can be run for all backends/brokers when needed.

I hope you'd like this :)

Thanks,
Vimukthi