### PR TITLE
Don't include headers if there are none

### DIFF
--- a/message.go
+++ b/message.go
@@ -12,7 +12,7 @@ import (
 // CeleryMessage is actual message to be sent to Redis
 type CeleryMessage struct {
 	Body            string                 `json:"body"`
-	Headers         map[string]interface{} `json:"headers"`
+	Headers         map[string]interface{} `json:"headers,omitempty"`
 	ContentType     string                 `json:"content-type"`
 	Properties      CeleryProperties       `json:"properties"`
 	ContentEncoding string                 `json:"content-encoding"`


### PR DESCRIPTION
When interacting with a Celery worker that needs to add more headers for a retry, this field being empty results in a `null` entry in the resulting JSON, which the Celery worker is unable to get past. By removing the entry from the payload, the worker will create the dictionary properly.