### PR TITLE
Try and make the library a little more robust when the AMQP instance is not available

### DIFF
--- a/amqp_backend.go
+++ b/amqp_backend.go
@@ -27,18 +27,31 @@ func NewAMQPCeleryBackendByConnAndChannel(conn *amqp.Connection, channel *amqp.C
 }
 
 // NewAMQPCeleryBackend creates new AMQPCeleryBackend
-func NewAMQPCeleryBackend(host string) *AMQPCeleryBackend {
-	backend := NewAMQPCeleryBackendByConnAndChannel(NewAMQPConnection(host))
+func NewAMQPCeleryBackend(host string) (*AMQPCeleryBackend, error) {
+	conn, channel, err := NewAMQPConnection(host)
+	if err != nil {
+		return nil, err
+	}
+
+	backend := NewAMQPCeleryBackendByConnAndChannel(conn, channel)
 	backend.host = host
-	return backend
+
+	return backend, nil
 }
 
 // Reconnect reconnects to AMQP server
-func (b *AMQPCeleryBackend) Reconnect() {
+func (b *AMQPCeleryBackend) Reconnect() error {
 	b.connection.Close()
-	conn, channel := NewAMQPConnection(b.host)
+
+	conn, channel, err := NewAMQPConnection(b.host)
+	if err != nil {
+		return err
+	}
+
 	b.Channel = channel
 	b.connection = conn
+
+	return nil
 }
 
 // GetResult retrieves result from AMQP queue

--- a/backend_test.go
+++ b/backend_test.go
@@ -9,10 +9,16 @@ import (
 )
 
 func getBackends() []CeleryBackend {
-	return []CeleryBackend{
-		NewRedisCeleryBackend("redis://localhost:6379"),
-		NewAMQPCeleryBackend("amqp://"),
+	backends := make([]CeleryBackend, 0)
+
+	backends = append(backends, NewRedisCeleryBackend("redis://localhost:6379"))
+
+	celeryBackend, err := NewAMQPCeleryBackend("amqp://")
+	if err == nil {
+		backends = append(backends, celeryBackend)
 	}
+
+	return backends
 }
 
 // TestGetResult is Redis specific test to get result from backend

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -46,8 +46,16 @@ func (m *multiplyKwargs) RunTask() (interface{}, error) {
 }
 
 func getAMQPClient() (*CeleryClient, error) {
-	amqpBroker := NewAMQPCeleryBroker("amqp://")
-	amqpBackend := NewAMQPCeleryBackend("amqp://")
+	amqpBroker, err := NewAMQPCeleryBroker("amqp://")
+	if err != nil {
+		return nil, err
+	}
+
+	amqpBackend, err := NewAMQPCeleryBackend("amqp://")
+	if err != nil {
+		return nil, err
+	}
+
 	return NewCeleryClient(amqpBroker, amqpBackend, 4)
 }
 


### PR DESCRIPTION
Changed the AMQP creation functions to not throw an uncatchable panic, but instead pass the error back to the calling code where it could be handled more gracefully.