### PR TITLE
fixing and reformatting tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ before_install:
 install:
   - dep ensure
 script:
-  - golangci-lint run -D errcheck
+  - golangci-lint run
   - go test -v -cover ./...
   - goveralls -service=travis-ci

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build-lint:
 
 .PHONY: lint
 lint: build-lint
-	golangci-lint run -D errcheck
+	golangci-lint run
 
 .PHONY: test
 test:

--- a/amqp_broker.go
+++ b/amqp_broker.go
@@ -109,7 +109,6 @@ func (b *AMQPCeleryBroker) StartConsumingChannel() error {
 // SendCeleryMessage sends CeleryMessage to broker
 func (b *AMQPCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
 	taskMessage := message.GetTaskMessage()
-	//log.Printf("sending task ID %s\n", taskMessage.ID)
 	queueName := "celery"
 	_, err := b.QueueDeclare(
 		queueName, // name

--- a/backend_test.go
+++ b/backend_test.go
@@ -10,92 +10,131 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
-func getBackends() []CeleryBackend {
-	return []CeleryBackend{
-		NewRedisCeleryBackend("redis://localhost:6379"),
-		NewAMQPCeleryBackend("amqp://"),
+// TestBackendRedisGetResult is Redis specific test to get result from backend
+func TestBackendRedisGetResult(t *testing.T) {
+	testCases := []struct {
+		name    string
+		backend *RedisCeleryBackend
+	}{
+		{
+			name:    "get result from redis backend",
+			backend: redisBackend,
+		},
+	}
+	for _, tc := range testCases {
+		taskID := uuid.Must(uuid.NewV4()).String()
+		// value must be float64 for testing due to json limitation
+		value := reflect.ValueOf(rand.Float64())
+		resultMessage := getReflectionResultMessage(&value)
+		messageBytes, err := json.Marshal(resultMessage)
+		if err != nil {
+			t.Errorf("test '%s': error marshalling result message: %v", tc.name, err)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		conn := tc.backend.Get()
+		defer conn.Close()
+		_, err = conn.Do("SETEX", fmt.Sprintf("celery-task-meta-%s", taskID), 86400, messageBytes)
+		if err != nil {
+			t.Errorf("test '%s': error setting result message to celery: %v", tc.name, err)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		res, err := tc.backend.GetResult(taskID)
+		if err != nil {
+			t.Errorf("test '%s': error getting result from backend: %v", tc.name, err)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		if !reflect.DeepEqual(res, resultMessage) {
+			t.Errorf("test '%s': result message received %v is different from original %v", tc.name, res, resultMessage)
+		}
+		releaseResultMessage(resultMessage)
 	}
 }
 
-// TestGetResult is Redis specific test to get result from backend
-func TestGetResult(t *testing.T) {
-	backend := NewRedisCeleryBackend("redis://localhost:6379")
-	taskID := uuid.Must(uuid.NewV4()).String()
-
-	// value must be float64 for testing due to json limitation
-	value := reflect.ValueOf(rand.Float64())
-	resultMessage := getReflectionResultMessage(&value)
-	defer releaseResultMessage(resultMessage)
-	messageBytes, err := json.Marshal(resultMessage)
-	if err != nil {
-		t.Errorf("error marshalling result message: %v", err)
+// TestBackendRedisSetResult is Redis specific test to set result to backend
+func TestBackendRedisSetResult(t *testing.T) {
+	testCases := []struct {
+		name    string
+		backend *RedisCeleryBackend
+	}{
+		{
+			name:    "set result to redis backend",
+			backend: redisBackend,
+		},
 	}
-	conn := backend.Get()
-	defer conn.Close()
-	_, err = conn.Do("SETEX", fmt.Sprintf("celery-task-meta-%s", taskID), 86400, messageBytes)
-	if err != nil {
-		t.Errorf("error setting result message to celery: %v", err)
-	}
-	// get result
-	res, err := backend.GetResult(taskID)
-	if err != nil {
-		t.Errorf("error getting result from backend: %v", err)
-	}
-	if !reflect.DeepEqual(res, resultMessage) {
-		t.Errorf("result message received %v is different from original %v", res, resultMessage)
-	}
-}
-
-// TestSetResult is Redis specific test to set result to backend
-func TestSetResult(t *testing.T) {
-	backend := NewRedisCeleryBackend("redis://localhost:6379")
-	taskID := uuid.Must(uuid.NewV4()).String()
-	value := reflect.ValueOf(rand.Float64())
-	resultMessage := getReflectionResultMessage(&value)
-	releaseResultMessage(resultMessage)
-	// set result
-	err := backend.SetResult(taskID, resultMessage)
-	if err != nil {
-		t.Errorf("error setting result to backend: %v", err)
-	}
-	conn := backend.Get()
-	defer conn.Close()
-	val, err := conn.Do("GET", fmt.Sprintf("celery-task-meta-%s", taskID))
-	if err != nil {
-		t.Errorf("error getting data from redis: %v", err)
-	}
-	if val == nil {
-		t.Errorf("result not available from redis")
-	}
-	var res ResultMessage
-	err = json.Unmarshal(val.([]byte), &res)
-	if err != nil {
-		t.Errorf("error parsing json result")
-	}
-	if !reflect.DeepEqual(&res, resultMessage) {
-		t.Errorf("result message received %v is different from original %v", &res, resultMessage)
-	}
-}
-
-// TestSetGetResult tests set/get result feature for all backends
-func TestSetGetResult(t *testing.T) {
-	for _, backend := range getBackends() {
+	for _, tc := range testCases {
 		taskID := uuid.Must(uuid.NewV4()).String()
 		value := reflect.ValueOf(rand.Float64())
 		resultMessage := getReflectionResultMessage(&value)
-		defer releaseResultMessage(resultMessage)
-		// set result
-		err := backend.SetResult(taskID, resultMessage)
+		err := tc.backend.SetResult(taskID, resultMessage)
+		if err != nil {
+			t.Errorf("test '%s': error setting result to backend: %v", tc.name, err)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		conn := tc.backend.Get()
+		defer conn.Close()
+		val, err := conn.Do("GET", fmt.Sprintf("celery-task-meta-%s", taskID))
+		if err != nil {
+			t.Errorf("test '%s': error getting data from redis: %v", tc.name, err)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		if val == nil {
+			t.Errorf("test '%s': result not available from redis", tc.name)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		var res ResultMessage
+		err = json.Unmarshal(val.([]byte), &res)
+		if err != nil {
+			t.Errorf("test '%s': error parsing json result", tc.name)
+			releaseResultMessage(resultMessage)
+			continue
+		}
+		if !reflect.DeepEqual(&res, resultMessage) {
+			t.Errorf("test '%s': result message received %v is different from original %v", tc.name, &res, resultMessage)
+		}
+		releaseResultMessage(resultMessage)
+	}
+}
+
+// TestBackendSetGetResult tests set/get result feature for all backends
+func TestBackendSetGetResult(t *testing.T) {
+	testCases := []struct {
+		name    string
+		backend CeleryBackend
+	}{
+		{
+			name:    "set/get result to redis backend",
+			backend: redisBackend,
+		},
+		{
+			name:    "set/get result to amqp backend",
+			backend: amqpBackend,
+		},
+	}
+	for _, tc := range testCases {
+		taskID := uuid.Must(uuid.NewV4()).String()
+		value := reflect.ValueOf(rand.Float64())
+		resultMessage := getReflectionResultMessage(&value)
+		err := tc.backend.SetResult(taskID, resultMessage)
 		if err != nil {
 			t.Errorf("error setting result to backend: %v", err)
+			releaseResultMessage(resultMessage)
+			continue
 		}
-		// get result
-		res, err := backend.GetResult(taskID)
+		res, err := tc.backend.GetResult(taskID)
 		if err != nil {
 			t.Errorf("error getting result from backend: %v", err)
+			releaseResultMessage(resultMessage)
+			continue
 		}
 		if !reflect.DeepEqual(res, resultMessage) {
 			t.Errorf("result message received %v is different from original %v", res, resultMessage)
 		}
+		releaseResultMessage(resultMessage)
 	}
 }

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -13,24 +13,24 @@ import (
 const TIMEOUT = 2 * time.Second
 
 var (
-	redisBroker  = NewRedisCeleryBroker("redis://localhost:6379")
-	redisBackend = NewRedisCeleryBackend("redis://localhost:6379")
+	redisBroker  = NewRedisCeleryBroker("redis://")
+	redisBackend = NewRedisCeleryBackend("redis://")
 	amqpBroker   = NewAMQPCeleryBroker("amqp://")
 	amqpBackend  = NewAMQPCeleryBackend("amqp://")
 )
 
-// TestExecutionSuccess covers test cases
-// with successful function execution
-func TestExecutionSuccess(t *testing.T) {
+// TestInteger tests successful function execution
+// with integer arguments and return value
+func TestInteger(t *testing.T) {
 	testCases := []struct {
 		name     string
 		broker   CeleryBroker
 		backend  CeleryBackend
 		taskName string
 		taskFunc interface{}
-		inA      interface{}
-		inB      interface{}
-		expected interface{}
+		inA      int
+		inB      int
+		expected int
 	}{
 		{
 			name:     "integer addition with redis broker/backend",
@@ -40,7 +40,7 @@ func TestExecutionSuccess(t *testing.T) {
 			taskFunc: addInt,
 			inA:      2485,
 			inB:      6468,
-			expected: 8953.0, // json always return float64
+			expected: 8953,
 		},
 		{
 			name:     "integer addition with amqp broker/backend",
@@ -50,8 +50,110 @@ func TestExecutionSuccess(t *testing.T) {
 			taskFunc: addInt,
 			inA:      2485,
 			inB:      6468,
-			expected: 8953.0, // json always return float64
+			expected: 8953,
 		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		// json always return float64 intead of int
+		if tc.expected != int(res.(float64)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestIntegerNamedArguments tests successful function execution
+// with integer arguments and return value
+func TestIntegerNamedArguments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      int
+		inB      int
+		expected int
+	}{
+		{
+			name:     "integer addition (named arguments) with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addIntTask{},
+			inA:      2485,
+			inB:      6468,
+			expected: 8953,
+		},
+		{
+			name:     "integer addition (named arguments) with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addIntTask{},
+			inA:      2485,
+			inB:      6468,
+			expected: 8953,
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		// json always return float64 intead of int
+		if tc.expected != int(res.(float64)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestString tests successful function execution
+// with string arguments and return value
+func TestString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      string
+		inB      string
+		expected string
+	}{
 		{
 			name:     "string addition with redis broker/backend",
 			broker:   redisBroker,
@@ -72,6 +174,106 @@ func TestExecutionSuccess(t *testing.T) {
 			inB:      "world",
 			expected: "helloworld",
 		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(string) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestStringNamedArguments tests successful function execution
+// with string arguments and return value
+func TestStringNamedArguments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      string
+		inB      string
+		expected string
+	}{
+		{
+			name:     "string addition (named arguments) with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addStrTask{},
+			inA:      "hello",
+			inB:      "world",
+			expected: "helloworld",
+		},
+		{
+			name:     "string addition (named arguments) with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addStrTask{},
+			inA:      "hello",
+			inB:      "world",
+			expected: "helloworld",
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(string) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestStringInteger tests successful function execution
+// with string and integer arguments and string return value
+func TestStringInteger(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      string
+		inB      int
+		expected string
+	}{
 		{
 			name:     "integer and string concatenation with redis broker/backend",
 			broker:   redisBroker,
@@ -92,6 +294,106 @@ func TestExecutionSuccess(t *testing.T) {
 			inB:      5,
 			expected: "hello5",
 		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(string) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestStringIntegerNamedArguments tests successful function execution
+// with string and integer arguments and string return value
+func TestStringIntegerNamedArguments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      string
+		inB      int
+		expected string
+	}{
+		{
+			name:     "integer and string concatenation (named arguments) with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addStrIntTask{},
+			inA:      "hello",
+			inB:      5,
+			expected: "hello5",
+		},
+		{
+			name:     "integer and string concatenation (named arguments) with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addStrIntTask{},
+			inA:      "hello",
+			inB:      5,
+			expected: "hello5",
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(string) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestFloat tests successful function execution
+// with float64 arguments and return value
+func TestFloat(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      float64
+		inB      float64
+		expected float64
+	}{
 		{
 			name:     "float addition with redis broker/backend",
 			broker:   redisBroker,
@@ -112,28 +414,232 @@ func TestExecutionSuccess(t *testing.T) {
 			inB:      5.3688,
 			expected: 8.8268,
 		},
-		// Bug(sickyoon): float32 as am argument throws a panic
-		// https://github.com/gocelery/gocelery/issues/75
-		// {
-		// 	name:     "float32 addition with redis broker/backend",
-		// 	broker:   redisBroker,
-		// 	backend:  redisBackend,
-		// 	taskName: uuid.Must(uuid.NewV4()).String(),
-		// 	taskFunc: addFloat32,
-		// 	inA:      3.4580,
-		// 	inB:      5.3688,
-		// 	expected: float32(8.8268),
-		// },
-		// {
-		// 	name:     "float32 addition with amqp broker/backend",
-		// 	broker:   amqpBroker,
-		// 	backend:  amqpBackend,
-		// 	taskName: uuid.Must(uuid.NewV4()).String(),
-		// 	taskFunc: addFloat32,
-		// 	inA:      3.4580,
-		// 	inB:      5.3688,
-		// 	expected: float32(8.8268),
-		// },
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(float64) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestFloatNamedArguments tests successful function execution
+// with float64 arguments and return value
+func TestFloatNamedArguments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      float64
+		inB      float64
+		expected float64
+	}{
+		{
+			name:     "float addition with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addFloatTask{},
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: 8.8268,
+		},
+		{
+			name:     "float addition with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addFloatTask{},
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: 8.8268,
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != res.(float64) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestFloat32 tests successful function execution
+// with float32 arguments and return value
+// Bug(sickyoon): float32 as an argument throws a panic
+// https://github.com/gocelery/gocelery/issues/75
+func TestFloat32(t *testing.T) {
+	t.Skip("Bug(sickyoon): float32 as an argument throws a panic: https://github.com/gocelery/gocelery/issues/75")
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      float32
+		inB      float32
+		expected float32
+	}{
+		{
+			name:     "float32 addition with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addFloat32,
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: float32(8.8268),
+		},
+		{
+			name:     "float32 addition with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addFloat32,
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: 8.8268,
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != float32(res.(float64)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestFloat32NamedArguments tests successful function execution
+// with float32 arguments and return value
+// Bug(sickyoon): float32 as an argument throws a panic
+// https://github.com/gocelery/gocelery/issues/75
+func TestFloat32NamedArguments(t *testing.T) {
+	t.Skip("Bug(sickyoon): float32 as an argument throws a panic: https://github.com/gocelery/gocelery/issues/75")
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      float32
+		inB      float32
+		expected float32
+	}{
+		{
+			name:     "float32 addition with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addFloat32Task{},
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: float32(8.8268),
+		},
+		{
+			name:     "float32 addition with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &addFloat32Task{},
+			inA:      3.4580,
+			inB:      5.3688,
+			expected: float32(8.8268),
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != float32(res.(float64)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestBool tests successful function execution
+// with boolean arguments and return value
+func TestBool(t *testing.T) {
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      bool
+		inB      bool
+		expected bool
+	}{
 		{
 			name:     "boolean and operation with redis broker/backend",
 			broker:   redisBroker,
@@ -162,135 +668,35 @@ func TestExecutionSuccess(t *testing.T) {
 		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
 		if err != nil {
 			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
-			return
+			cli.StopWorker()
+			continue
 		}
 		res, err := asyncResult.Get(TIMEOUT)
 		if err != nil {
 			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
 		}
-		if !reflect.DeepEqual(tc.expected, res) {
-			t.Errorf("returned result %+v is different from expected result %+v", res, tc.expected)
-			return
+		if tc.expected != res.(bool) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
 		}
 		cli.StopWorker()
 	}
 }
 
-// TestExecutionNamedArguments covers test cases
-// with successful execution of functions with named arguments (kwargs)
-func TestExecutionNamedArgumentsSuccess(t *testing.T) {
+// TestBoolNamedArguments tests successful function execution
+// with boolean arguments and return value
+func TestBoolNamedArguments(t *testing.T) {
 	testCases := []struct {
 		name     string
 		broker   CeleryBroker
 		backend  CeleryBackend
 		taskName string
 		taskFunc interface{}
-		inA      interface{}
-		inB      interface{}
-		expected interface{}
+		inA      bool
+		inB      bool
+		expected bool
 	}{
-		{
-			name:     "integer addition (named arguments) with redis broker/backend",
-			broker:   redisBroker,
-			backend:  redisBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addIntTask{},
-			inA:      2485,
-			inB:      6468,
-			expected: 8953.0, // json always return float64
-		},
-		{
-			name:     "integer addition (named arguments) with amqp broker/backend",
-			broker:   amqpBroker,
-			backend:  amqpBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addIntTask{},
-			inA:      2485,
-			inB:      6468,
-			expected: 8953.0, // json always return float64
-		},
-		{
-			name:     "string addition (named arguments) with redis broker/backend",
-			broker:   redisBroker,
-			backend:  redisBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addStrTask{},
-			inA:      "hello",
-			inB:      "world",
-			expected: "helloworld",
-		},
-		{
-			name:     "string addition (named arguments) with amqp broker/backend",
-			broker:   amqpBroker,
-			backend:  amqpBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addStrTask{},
-			inA:      "hello",
-			inB:      "world",
-			expected: "helloworld",
-		},
-		{
-			name:     "integer and string concatenation (named arguments) with redis broker/backend",
-			broker:   redisBroker,
-			backend:  redisBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addStrIntTask{},
-			inA:      "hello",
-			inB:      5,
-			expected: "hello5",
-		},
-		{
-			name:     "integer and string concatenation (named arguments) with amqp broker/backend",
-			broker:   amqpBroker,
-			backend:  amqpBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addStrIntTask{},
-			inA:      "hello",
-			inB:      5,
-			expected: "hello5",
-		},
-		{
-			name:     "float addition (named arguments) with redis broker/backend",
-			broker:   redisBroker,
-			backend:  redisBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addFloatTask{},
-			inA:      3.4580,
-			inB:      5.3688,
-			expected: 8.8268,
-		},
-		{
-			name:     "float addition (named arguments) with amqp broker/backend",
-			broker:   amqpBroker,
-			backend:  amqpBackend,
-			taskName: uuid.Must(uuid.NewV4()).String(),
-			taskFunc: &addFloatTask{},
-			inA:      3.4580,
-			inB:      5.3688,
-			expected: 8.8268,
-		},
-		// Bug(sickyoon): float32 as am argument throws a panic
-		// https://github.com/gocelery/gocelery/issues/75
-		// {
-		// 	name:     "float32 addition with redis broker/backend",
-		// 	broker:   redisBroker,
-		// 	backend:  redisBackend,
-		// 	taskName: uuid.Must(uuid.NewV4()).String(),
-		// 	taskFunc: &addFloat32Task{},
-		// 	inA:      3.4580,
-		// 	inB:      5.3688,
-		// 	expected: float32(8.8268),
-		// },
-		// {
-		// 	name:     "float32 addition with amqp broker/backend",
-		// 	broker:   amqpBroker,
-		// 	backend:  amqpBackend,
-		// 	taskName: uuid.Must(uuid.NewV4()).String(),
-		// 	taskFunc: &addFloat32Task{},
-		// 	inA:      3.4580,
-		// 	inB:      5.3688,
-		// 	expected: float32(8.8268),
-		// },
 		{
 			name:     "boolean and operation (named arguments) with redis broker/backend",
 			broker:   redisBroker,
@@ -324,16 +730,198 @@ func TestExecutionNamedArgumentsSuccess(t *testing.T) {
 			},
 		)
 		if err != nil {
-			t.Errorf("test '%s': failed to submit request for task: %s: %+v", tc.name, tc.taskName, err)
-			return
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
 		}
 		res, err := asyncResult.Get(TIMEOUT)
 		if err != nil {
-			t.Errorf("failed to get result for task %s: %+v", tc.taskName, err)
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
 		}
-		if !reflect.DeepEqual(tc.expected, res) {
-			t.Errorf("test '%s': returned result %v is different from expected result %v", tc.name, res, tc.expected)
-			return
+		if tc.expected != res.(bool) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestArrayIntNamedArguments tests successful function execution
+// with array arguments and integer return value
+func TestArrayIntNamedArguments(t *testing.T) {
+	t.Skip("Bug(sickyoon): array as an argument returns nil: https://github.com/gocelery/gocelery/issues/74")
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      []string
+		inB      []string
+		expected int
+	}{
+		{
+			name:     "maximum array length (named arguments) with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &maxArrLenTask{},
+			inA:      []string{"a", "b", "c", "d"},
+			inB:      []string{"e", "f", "g", "h"},
+			expected: 4,
+		},
+		{
+			name:     "maximum array length (named arguments) with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: &maxArrLenTask{},
+			inA:      []string{"a", "b", "c", "d"},
+			inB:      []string{"e", "f", "g", "h"},
+			expected: 4,
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.DelayKwargs(
+			tc.taskName,
+			map[string]interface{}{
+				"a": tc.inA,
+				"b": tc.inB,
+			},
+		)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if tc.expected != int(res.(float64)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestArray tests successful function execution
+// with array arguments and return value
+func TestArray(t *testing.T) {
+	t.Skip("Bug(sickyoon): array as an argument returns nil: https://github.com/gocelery/gocelery/issues/74")
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      []string
+		inB      []string
+		expected []string
+	}{
+		{
+			name:     "array addition with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addArr,
+			inA:      []string{"a", "b", "c", "d"},
+			inB:      []string{"e", "f", "g", "h"},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+		},
+		{
+			name:     "array addition with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addArr,
+			inA:      []string{"a", "b", "c", "d"},
+			inB:      []string{"e", "f", "g", "h"},
+			expected: []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if !reflect.DeepEqual(tc.expected, res.([]string)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
+		}
+		cli.StopWorker()
+	}
+}
+
+// TestMap tests successful function execution
+// with map arguments and return value
+func TestMap(t *testing.T) {
+	t.Skip("Bug(sickyoon): map as an argument returns nil: https://github.com/gocelery/gocelery/issues/74")
+	testCases := []struct {
+		name     string
+		broker   CeleryBroker
+		backend  CeleryBackend
+		taskName string
+		taskFunc interface{}
+		inA      map[string]string
+		inB      map[string]string
+		expected map[string]string
+	}{
+		{
+			name:     "integer addition with redis broker/backend",
+			broker:   redisBroker,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addMap,
+			inA:      map[string]string{"a": "a"},
+			inB:      map[string]string{"b": "b"},
+			expected: map[string]string{"a": "a", "b": "b"},
+		},
+		{
+			name:     "integer addition with amqp broker/backend",
+			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addMap,
+			inA:      map[string]string{"a": "a"},
+			inB:      map[string]string{"b": "b"},
+			expected: map[string]string{"a": "a", "b": "b"},
+		},
+	}
+	for _, tc := range testCases {
+		cli, _ := NewCeleryClient(tc.broker, tc.backend, 1)
+		cli.Register(tc.taskName, tc.taskFunc)
+		cli.StartWorker()
+		asyncResult, err := cli.Delay(tc.taskName, tc.inA, tc.inB)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		res, err := asyncResult.Get(TIMEOUT)
+		if err != nil {
+			t.Errorf("test '%s': failed to get result for task %s: %+v", tc.name, tc.taskName, err)
+			cli.StopWorker()
+			continue
+		}
+		if !reflect.DeepEqual(tc.expected, res.(map[string]string)) {
+			t.Errorf("test '%s': returned result %+v is different from expected result %+v", tc.name, res, tc.expected)
 		}
 		cli.StopWorker()
 	}
@@ -489,39 +1077,39 @@ func (a *addFloatTask) RunTask() (interface{}, error) {
 // https://github.com/gocelery/gocelery/issues/75
 
 // addFloat32 returns sum of two float32 values
-// func addFloat32(a, b float32) float32 {
-// 	return a + b
-// }
+func addFloat32(a, b float32) float32 {
+	return a + b
+}
 
 // addFloat32Task returns sum of two float32 values
-// type addFloat32Task struct {
-// 	a float32
-// 	b float32
-// }
+type addFloat32Task struct {
+	a float32
+	b float32
+}
 
-// func (a *addFloat32Task) ParseKwargs(kwargs map[string]interface{}) error {
-// 	kwargA, ok := kwargs["a"]
-// 	if !ok {
-// 		return fmt.Errorf("undefined kwarg a")
-// 	}
-// 	a.a, ok = kwargA.(float32)
-// 	if !ok {
-// 		return fmt.Errorf("malformed kwarg a")
-// 	}
-// 	kwargB, ok := kwargs["b"]
-// 	if !ok {
-// 		return fmt.Errorf("undefined kwarg b")
-// 	}
-// 	a.b, ok = kwargB.(float32)
-// 	if !ok {
-// 		return fmt.Errorf("malformed kwarg b")
-// 	}
-// 	return nil
-// }
+func (a *addFloat32Task) ParseKwargs(kwargs map[string]interface{}) error {
+	kwargA, ok := kwargs["a"]
+	if !ok {
+		return fmt.Errorf("undefined kwarg a")
+	}
+	a.a, ok = kwargA.(float32)
+	if !ok {
+		return fmt.Errorf("malformed kwarg a")
+	}
+	kwargB, ok := kwargs["b"]
+	if !ok {
+		return fmt.Errorf("undefined kwarg b")
+	}
+	a.b, ok = kwargB.(float32)
+	if !ok {
+		return fmt.Errorf("malformed kwarg b")
+	}
+	return nil
+}
 
-// func (a *addFloat32Task) RunTask() (interface{}, error) {
-// 	return a.a + a.b, nil
-// }
+func (a *addFloat32Task) RunTask() (interface{}, error) {
+	return a.a + a.b, nil
+}
 
 // andBool returns result of and operation of two given boolean values
 func andBool(a, b bool) bool {
@@ -557,4 +1145,56 @@ func (a *andBoolTask) ParseKwargs(kwargs map[string]interface{}) error {
 
 func (a *andBoolTask) RunTask() (interface{}, error) {
 	return a.a && a.b, nil
+}
+
+// maxArrLenTask returns maximum length of two given arrays
+type maxArrLenTask struct {
+	a []string
+	b []string
+}
+
+// ParseKwargs parses named arguments for maxArrLenTask
+func (m *maxArrLenTask) ParseKwargs(kwargs map[string]interface{}) error {
+	kwargA, ok := kwargs["a"]
+	if !ok {
+		return fmt.Errorf("undefined kwarg a")
+	}
+	m.a, ok = kwargA.([]string)
+	if !ok {
+		return fmt.Errorf("malformed kwarg a")
+	}
+	kwargB, ok := kwargs["b"]
+	if !ok {
+		return fmt.Errorf("undefined kwarg b")
+	}
+	m.b, ok = kwargB.([]string)
+	if !ok {
+		return fmt.Errorf("malformed kwarg b")
+	}
+	return nil
+}
+
+// RunTask returns maximum length of two given arrays from maxArrLenTask struct
+func (m *maxArrLenTask) RunTask() (interface{}, error) {
+	if len(m.a) > len(m.b) {
+		return len(m.a), nil
+	}
+	return len(m.b), nil
+}
+
+// addArr concatenates two slices together
+func addArr(a, b []interface{}) []interface{} {
+	return append(a, b...)
+}
+
+// addMap concatenates two maps together
+func addMap(a, b map[string]interface{}) map[string]interface{} {
+	c := map[string]interface{}{}
+	for k, v := range a {
+		c[k] = v
+	}
+	for k, v := range b {
+		c[k] = v
+	}
+	return c
 }

--- a/message.go
+++ b/message.go
@@ -138,7 +138,7 @@ func getTaskMessage(task string) *TaskMessage {
 	msg.Task = task
 	msg.Args = make([]interface{}, 0)
 	msg.Kwargs = make(map[string]interface{})
-	msg.ETA = time.Now().Format(time.RFC3339)
+	msg.ETA = ""
 	return msg
 }
 

--- a/redis_broker.go
+++ b/redis_broker.go
@@ -74,7 +74,9 @@ func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 	}
 	// parse
 	var message CeleryMessage
-	json.Unmarshal(messageList[1].([]byte), &message)
+	if err := json.Unmarshal(messageList[1].([]byte), &message); err != nil {
+		return nil, err
+	}
 	return &message, nil
 }
 


### PR DESCRIPTION
## fixing and reformatting tests
added additional broker test for amqp which is failing due to eta bug https://github.com/gocelery/gocelery/issues/81
this test is expected to pass once the bug is fixed.

----------------
UPDATE: bug turns out to be memory management bug within the broker test. this PR fixes it.
Also errcheck linter is re-enabled.