### PR TITLE
bugfix: set eta as nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,15 @@ Celery must be configured to use **json** instead of default **pickle** encoding
 This is because Go currently has no stable support for decoding pickle objects.
 Pass below configuration parameters to use **json**.
 
+Starting from version 4.0, Celery uses message protocol version 2 as default value.
+GoCelery does not yet support message protocol version 2, so you must explicitly set `CELERY_TASK_PROTOCOL` to 1.
+
 ```python
 CELERY_TASK_SERIALIZER='json',
 CELERY_ACCEPT_CONTENT=['json'],  # Ignore other content
 CELERY_RESULT_SERIALIZER='json',
 CELERY_ENABLE_UTC=True,
+CELERY_TASK_PROTOCOL=1,
 ```
 
 ## Example

--- a/example/worker.py
+++ b/example/worker.py
@@ -6,8 +6,8 @@ from celery import Celery
 
 app = Celery(
     'tasks',
-    broker='redis://localhost:6379',
-    backend='redis://localhost:6379',
+    broker='redis://',
+    backend='redis://',
 )
 
 app.conf.update(
@@ -15,14 +15,15 @@ app.conf.update(
     CELERY_ACCEPT_CONTENT=['json'],  # Ignore other content
     CELERY_RESULT_SERIALIZER='json',
     CELERY_ENABLE_UTC=True,
+    CELERY_TASK_PROTOCOL=1,
 )
 
 
 @app.task
-def add(x, y):
-    return x + y
+def add(a, b):
+    return a + b
 
 
 @app.task
-def add_reflect(x, y):
-    return x + y
+def add_reflect(a, b):
+    return a + b

--- a/message.go
+++ b/message.go
@@ -116,7 +116,7 @@ type TaskMessage struct {
 	Args    []interface{}          `json:"args"`
 	Kwargs  map[string]interface{} `json:"kwargs"`
 	Retries int                    `json:"retries"`
-	ETA     string                 `json:"eta"`
+	ETA     *string                `json:"eta"`
 }
 
 func (tm *TaskMessage) reset() {
@@ -128,11 +128,12 @@ func (tm *TaskMessage) reset() {
 
 var taskMessagePool = sync.Pool{
 	New: func() interface{} {
+		eta := time.Now().Format(time.RFC3339)
 		return &TaskMessage{
 			ID:      uuid.Must(uuid.NewV4()).String(),
 			Retries: 0,
 			Kwargs:  nil,
-			ETA:     time.Now().Format(time.RFC3339),
+			ETA:     &eta,
 		}
 	},
 }
@@ -142,7 +143,7 @@ func getTaskMessage(task string) *TaskMessage {
 	msg.Task = task
 	msg.Args = make([]interface{}, 0)
 	msg.Kwargs = make(map[string]interface{})
-	msg.ETA = ""
+	msg.ETA = nil
 	return msg
 }
 

--- a/worker_test.go
+++ b/worker_test.go
@@ -90,7 +90,7 @@ func TestWorkerRunTask(t *testing.T) {
 			Args:    args,
 			Kwargs:  nil,
 			Retries: 1,
-			ETA:     "",
+			ETA:     nil,
 		}
 		resultMsg, err := celeryWorker.RunTask(taskMessage)
 		if err != nil {


### PR DESCRIPTION
ETA being set to empty string causes python celery worker to crash for celery version 4.0 and above.
https://github.com/gocelery/gocelery/issues/96