### PR TITLE
Make TaskID Field Public

### DIFF
--- a/gocelery.go
+++ b/gocelery.go
@@ -26,7 +26,7 @@ type CeleryBroker interface {
 // CeleryBackend is interface for celery backend database
 type CeleryBackend interface {
 	GetResult(string) (*ResultMessage, error) // must be non-blocking
-	SetResult(taskID string, result *ResultMessage) error
+	SetResult(TaskID string, result *ResultMessage) error
 }
 
 // NewCeleryClient creates new celery client
@@ -90,7 +90,7 @@ func (cc *CeleryClient) delay(task *TaskMessage) (*AsyncResult, error) {
 		return nil, err
 	}
 	return &AsyncResult{
-		taskID:  task.ID,
+		TaskID:  task.ID,
 		backend: cc.backend,
 	}, nil
 }
@@ -110,7 +110,7 @@ type CeleryTask interface {
 
 // AsyncResult represents pending result
 type AsyncResult struct {
-	taskID  string
+	TaskID  string
 	backend CeleryBackend
 	result  *ResultMessage
 }
@@ -123,7 +123,7 @@ func (ar *AsyncResult) Get(timeout time.Duration) (interface{}, error) {
 	for {
 		select {
 		case <-timeoutChan:
-			err := fmt.Errorf("%v timeout getting result for %s", timeout, ar.taskID)
+			err := fmt.Errorf("%v timeout getting result for %s", timeout, ar.TaskID)
 			return nil, err
 		case <-ticker.C:
 			val, err := ar.AsyncGet()
@@ -140,7 +140,7 @@ func (ar *AsyncResult) AsyncGet() (interface{}, error) {
 	if ar.result != nil {
 		return ar.result.Result, nil
 	}
-	val, err := ar.backend.GetResult(ar.taskID)
+	val, err := ar.backend.GetResult(ar.TaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -159,7 +159,7 @@ func (ar *AsyncResult) Ready() (bool, error) {
 	if ar.result != nil {
 		return true, nil
 	}
-	val, err := ar.backend.GetResult(ar.taskID)
+	val, err := ar.backend.GetResult(ar.TaskID)
 	if err != nil {
 		return false, err
 	}

--- a/gocelery.go
+++ b/gocelery.go
@@ -26,7 +26,7 @@ type CeleryBroker interface {
 // CeleryBackend is interface for celery backend database
 type CeleryBackend interface {
 	GetResult(string) (*ResultMessage, error) // must be non-blocking
-	SetResult(TaskID string, result *ResultMessage) error
+	SetResult(taskID string, result *ResultMessage) error
 }
 
 // NewCeleryClient creates new celery client


### PR DESCRIPTION
#104 Making TaskID a public field would allow the sender to retrieve the task's unique ID upon task generation by the client.

This come in handy particularly if the worker does not work on the task (on the queue) immediately and yet the sender wants an ID to keep a record of tasks being sent/ submitted.