### PR TITLE
Add simple custom routing for task messages on AMQP broker

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -48,7 +48,7 @@ func TestBrokerRedisSend(t *testing.T) {
 		}
 		conn := tc.broker.Get()
 		defer conn.Close()
-		messageJSON, err := conn.Do("BRPOP", tc.broker.queueName, "1")
+		messageJSON, err := conn.Do("BRPOP", tc.broker.routes[defaultRoute].Queue, "1")
 		if err != nil || messageJSON == nil {
 			t.Errorf("test '%s': failed to get celery message from broker: %v", tc.name, err)
 			releaseCeleryMessage(celeryMessage)
@@ -98,7 +98,7 @@ func TestBrokerRedisGet(t *testing.T) {
 		}
 		conn := tc.broker.Get()
 		defer conn.Close()
-		_, err = conn.Do("LPUSH", tc.broker.queueName, jsonBytes)
+		_, err = conn.Do("LPUSH", tc.broker.routes[defaultRoute].Queue, jsonBytes)
 		if err != nil {
 			t.Errorf("test '%s': failed to push celery message to redis: %v", tc.name, err)
 			releaseCeleryMessage(celeryMessage)
@@ -157,5 +157,195 @@ func TestBrokerSendGet(t *testing.T) {
 			t.Errorf("test '%s': received message %v different from original message %v", tc.name, message, originalMessage)
 		}
 		releaseCeleryMessage(celeryMessage)
+	}
+}
+
+func TestAMQPBrokerCustomRoutes(t *testing.T) {
+	test := "test amqp broker custom non-default route"
+
+	routedTaskMessage := getTaskMessage("routedTask")
+	defer releaseTaskMessage(routedTaskMessage)
+
+	encodedTaskMessage, err := routedTaskMessage.Encode()
+	if err != nil {
+		t.Errorf("failed to encode routed task message: %s", err)
+	}
+	celeryMessage := getCeleryMessage(encodedTaskMessage)
+	defer releaseCeleryMessage(celeryMessage)
+
+	if err != nil || celeryMessage == nil {
+		t.Errorf("test '%s': failed to construct celery message: %v", test, err)
+	}
+
+	broker := amqpBroker
+	broker.AddRoute("routedTask", &Route{
+		Exchange:   "test",
+		Queue:      "test",
+		RoutingKey: "test",
+	}) 
+
+	
+	err = broker.SendCeleryMessage(celeryMessage)	
+	if err != nil {
+		t.Errorf("test '%s': failed to send celery message to broker: %v", test, err)
+
+	}
+
+	// Since the broker can't yet consume from a custom queue, just
+	// directly check to make sure the message landed in the correct queue
+	_, amqpchannel := NewAMQPConnection("amqp://")
+	channel, err := amqpchannel.Consume("test", "", false, false, false, false, nil)
+	if err != nil {
+		t.Errorf("failed to start consumer on custom queue: %s", err)
+	}
+
+	// wait arbitrary time to allow message to propagate and consumer to set up
+	time.Sleep(1 * time.Second)
+
+	var taskMessage TaskMessage
+
+	select {
+	case delivery := <-channel:
+		deliveryAck(delivery)
+		if err := json.Unmarshal(delivery.Body, &taskMessage); err != nil {
+			t.Errorf("test '%s': failed to get celery message from amqp: %v", test, err)
+		}
+
+		originalMessage := celeryMessage.GetTaskMessage()
+		if !reflect.DeepEqual(taskMessage, *originalMessage) {
+			t.Errorf("test '%s': received message %v different from original message %v", test, taskMessage, originalMessage)
+		}
+
+	default:
+		t.Errorf("test '%s': failed to retrieve celery message from custom queue: consuming channel empty", test)
+	}
+
+	// delete the queue and close the channel used for checking the custom routed message
+	err = amqpchannel.Cancel("", true)
+	if err != nil {
+		t.Errorf("test '%s': failed to close amqp channel: %v", test, err)
+	}	
+
+	err = broker.DelRoute("test")
+	if err != nil {
+		t.Errorf("test '%s': failed to remove stale custom route: %v", test, err)
+	}
+}
+
+func TestRedisCustomRoute(t *testing.T) {
+	test := "test redis broker custom non-default route"
+
+	routedTaskMessage := getTaskMessage("routedTask")
+	defer releaseTaskMessage(routedTaskMessage)
+
+	encodedTaskMessage, err := routedTaskMessage.Encode()
+	if err != nil {
+		t.Errorf("failed to encode routed task message: %s", err)
+	}
+	celeryMessage := getCeleryMessage(encodedTaskMessage)
+	defer releaseCeleryMessage(celeryMessage)
+
+	if err != nil || celeryMessage == nil {
+		t.Errorf("test '%s': failed to construct celery message: %v", test, err)
+	}
+
+	broker := redisBroker
+	broker.AddRoute("routedTask", &Route{
+		Exchange:   "test",
+		Queue:      "test",
+		RoutingKey: "test",
+	}) 
+
+	err = broker.SendCeleryMessage(celeryMessage)	
+	if err != nil {
+		t.Errorf("test '%s': failed to send celery message to broker: %v", test, err)
+
+	}
+
+	conn := broker.Get()
+	defer conn.Close()
+	messageJSON, err := conn.Do("BLPOP", "test", "1")
+	if err != nil {
+		t.Errorf("test: '%v': failed to BLPOP from Redis queue: %v", test, err)
+	}
+
+	if messageJSON == nil {
+		t.Errorf("null message received from redis")
+	}
+
+	messageList := messageJSON.([]interface{})
+	if string(messageList[0].([]byte)) != "test" {
+		t.Errorf("test: '%s': invalid message retrieved from redis", test)
+	}
+
+	var taskMessage CeleryMessage
+	if err := json.Unmarshal(messageList[1].([]byte), &taskMessage); err != nil {
+		t.Errorf("test: '%s': failed to unmarshal message: %v", test, err)
+	}
+
+	originalMessage := celeryMessage.GetTaskMessage()
+	retrievedMessage := taskMessage.GetTaskMessage()
+	if !reflect.DeepEqual(retrievedMessage, originalMessage) {
+		t.Errorf("test: '%s': received message %v different from original message %v", test, retrievedMessage, originalMessage)
+	}
+
+	err = broker.DelRoute("test")
+	if err != nil {
+		t.Errorf("test: '%s': failed to remove stale custom queue from redis: %v", test, err)
+	}
+}
+
+// TestBrokerDefaultRouteChange tests set/get features for all brokers
+func TestBrokerDefaultRouteChange(t *testing.T) {
+	testCases := []struct {
+		name   string
+		broker CeleryBroker
+	}{
+		{
+			name:   "send/get task with changed default route for redis broker",
+			broker: redisBroker,
+		},
+		{
+			name:   "send/get task with changed default route for amqp broker",
+			broker: amqpBroker,
+		},
+	}
+	for _, tc := range testCases {
+		tc.broker.SetDefaultRoute(&Route{
+			Exchange:   "newExchange",
+			RoutingKey: "newQueue",
+			Queue:      "newQueue",
+		})
+
+		celeryMessage, err := makeCeleryMessage()
+		if err != nil || celeryMessage == nil {
+			t.Errorf("test '%s': failed to construct celery message: %v", tc.name, err)
+			continue
+		}
+		err = tc.broker.SendCeleryMessage(celeryMessage)
+		if err != nil {
+			t.Errorf("test '%s': failed to send celery message to broker: %v", tc.name, err)
+			releaseCeleryMessage(celeryMessage)
+			continue
+		}
+		// wait arbitrary time for message to propagate
+		time.Sleep(1 * time.Second)
+		message, err := tc.broker.GetTaskMessage()
+		if err != nil {
+			t.Errorf("test '%s': failed to get celery message from broker: %v", tc.name, err)
+			releaseCeleryMessage(celeryMessage)
+			continue
+		}
+		originalMessage := celeryMessage.GetTaskMessage()
+		if !reflect.DeepEqual(message, originalMessage) {
+			t.Errorf("test '%s': received message %v different from original message %v", tc.name, message, originalMessage)
+		}
+		releaseCeleryMessage(celeryMessage)
+		// make sure to set the broker's default route back to normal after test is complete
+		tc.broker.SetDefaultRoute(&Route{
+			Exchange:   defaultExchangeName,
+			RoutingKey: defaultQueueName,
+			Queue:      defaultQueueName,
+		})
 	}
 }

--- a/gocelery.go
+++ b/gocelery.go
@@ -21,6 +21,10 @@ type CeleryClient struct {
 type CeleryBroker interface {
 	SendCeleryMessage(*CeleryMessage) error
 	GetTaskMessage() (*TaskMessage, error) // must be non-blocking
+	AddRoute(taskName string, route *Route)
+	GetRoute(taskName string) *Route
+	DelRoute(taskName string) error
+	SetDefaultRoute(route *Route)
 }
 
 // CeleryBackend is interface for celery backend database
@@ -28,6 +32,19 @@ type CeleryBackend interface {
 	GetResult(string) (*ResultMessage, error) // must be non-blocking
 	SetResult(taskID string, result *ResultMessage) error
 }
+
+// Route stores message routing details
+type Route struct {
+	Exchange   string
+	RoutingKey string
+	Queue      string
+}
+
+const (
+	defaultRoute        = "default"
+	defaultQueueName    = "celery"
+	defaultExchangeName = "celery"
+)
 
 // NewCeleryClient creates new celery client
 func NewCeleryClient(broker CeleryBroker, backend CeleryBackend, numWorkers int) (*CeleryClient, error) {

--- a/redis_broker.go
+++ b/redis_broker.go
@@ -15,7 +15,7 @@ import (
 // RedisCeleryBroker is celery broker for redis
 type RedisCeleryBroker struct {
 	*redis.Pool
-	queueName string
+	routes map[string]*Route
 }
 
 // NewRedisPool creates pool of redis connections from given connection string
@@ -40,20 +40,27 @@ func NewRedisPool(uri string) *redis.Pool {
 // NewRedisCeleryBroker creates new RedisCeleryBroker based on given uri
 func NewRedisCeleryBroker(uri string) *RedisCeleryBroker {
 	return &RedisCeleryBroker{
-		Pool:      NewRedisPool(uri),
-		queueName: "celery",
+		Pool: NewRedisPool(uri),
+		routes: map[string]*Route{defaultRoute: &Route{
+			Exchange:   "", // Redis broker doesn't use exhanges or routing keys, only queue names
+			RoutingKey: "",
+			Queue:      defaultQueueName,
+		}},
 	}
 }
 
 // SendCeleryMessage sends CeleryMessage to redis queue
 func (cb *RedisCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
+	taskMessage := message.GetTaskMessage()
+	route := cb.GetRoute(taskMessage.Task)
+
 	jsonBytes, err := json.Marshal(message)
 	if err != nil {
 		return err
 	}
 	conn := cb.Get()
 	defer conn.Close()
-	_, err = conn.Do("LPUSH", cb.queueName, jsonBytes)
+	_, err = conn.Do("LPUSH", route.Queue, jsonBytes)
 	if err != nil {
 		return err
 	}
@@ -64,7 +71,7 @@ func (cb *RedisCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
 func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 	conn := cb.Get()
 	defer conn.Close()
-	messageJSON, err := conn.Do("BRPOP", cb.queueName, "1")
+	messageJSON, err := conn.Do("BRPOP", cb.routes[defaultRoute].Queue, "1")
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +79,7 @@ func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 		return nil, fmt.Errorf("null message received from redis")
 	}
 	messageList := messageJSON.([]interface{})
-	if string(messageList[0].([]byte)) != "celery" {
+	if string(messageList[0].([]byte)) != cb.routes[defaultRoute].Queue {
 		return nil, fmt.Errorf("not a celery message: %v", messageList[0])
 	}
 	var message CeleryMessage
@@ -89,4 +96,38 @@ func (cb *RedisCeleryBroker) GetTaskMessage() (*TaskMessage, error) {
 		return nil, err
 	}
 	return celeryMessage.GetTaskMessage(), nil
+}
+
+// AddRoute defines the destination queue for a task with a given name
+func (cb *RedisCeleryBroker) AddRoute(taskName string, route *Route) {
+	cb.routes[taskName] = route
+}
+
+// GetRoute returns a custom route for the specified task if one is defined, otherwise the default route
+func (cb *RedisCeleryBroker) GetRoute(taskName string) *Route {
+	route, ok := cb.routes[taskName]
+	if !ok {
+		return cb.routes[defaultRoute]
+	}
+
+	return route
+}
+
+// SetDefaultRoute modifies the default route
+func (cb *RedisCeleryBroker) SetDefaultRoute(route *Route) {
+	cb.routes[defaultRoute] = route
+}
+
+// DelRoute removes a specified route from the the local map and the key list from the redis server
+func (cb *RedisCeleryBroker) DelRoute(taskName string) error {
+	delete(cb.routes, taskName)
+
+	conn := cb.Get()
+	defer conn.Close()
+	_, err := conn.Do("DEL", taskName)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
The only non-backwards-compatible behaviour change here is that the default queue name and default exchange name are set to "celery" which I believe matches with the celery's defaults (see https://celery.readthedocs.io/en/latest/userguide/configuration.html#std:setting-task_default_queue).  

The routing mechanism just looks for an exact match on the specified task name.  Pattern matching like the Celery does in its routes could be added to GetRoute