### PR TITLE
Add custom queue on broker creation and allow setting queue later on

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -55,11 +55,6 @@ func TestBrokerRedisSend(t *testing.T) {
 			continue
 		}
 		messageList := messageJSON.([]interface{})
-		if string(messageList[0].([]byte)) != "celery" {
-			t.Errorf("test '%s': non celery message received", tc.name)
-			releaseCeleryMessage(celeryMessage)
-			continue
-		}
 		var message CeleryMessage
 		if err := json.Unmarshal(messageList[1].([]byte), &message); err != nil {
 			t.Errorf("test '%s': failed to unmarshal received message: %v", tc.name, err)

--- a/example_client_custom_queue_test.go
+++ b/example_client_custom_queue_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2019 Sick Yoon
+// This file is part of gocelery which is released under MIT license.
+// See file LICENSE for full license details.
+
+package gocelery
+
+import (
+	"log"
+	"math/rand"
+	"reflect"
+	"time"
+)
+
+func Example_clientWithCustomQueue() {
+
+	// initialize celery client
+	cli, _ := NewCeleryClient(
+		NewRedisCeleryBroker("redis://", "custom_queue"),
+		NewRedisCeleryBackend("redis://"),
+		1,
+	)
+
+	// prepare arguments
+	taskName := "worker.add"
+	argA := rand.Intn(10)
+	argB := rand.Intn(10)
+
+	// run task using "custom_queue"
+	asyncResult, err := cli.Delay(taskName, argA, argB)
+	if err != nil {
+		panic(err)
+	}
+
+	// get results from backend with timeout
+	res, err := asyncResult.Get(10 * time.Second)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("result: %+v of type %+v", res, reflect.TypeOf(res))
+
+	// run task using "another_queue"
+	cli.SetBrokerQueue("another_queue")
+	asyncResult, err = cli.Delay(taskName, argA, argB)
+	if err != nil {
+		panic(err)
+	}
+
+	// get results from backend with timeout
+	res, err = asyncResult.Get(10 * time.Second)
+	if err != nil {
+		panic(err)
+	}
+
+	log.Printf("result: %+v of type %+v", res, reflect.TypeOf(res))
+
+}

--- a/example_worker_custom_queue_test.go
+++ b/example_worker_custom_queue_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2019 Sick Yoon
+// This file is part of gocelery which is released under MIT license.
+// See file LICENSE for full license details.
+
+package gocelery
+
+import "time"
+
+func Example_workerWithCustomQueue() {
+
+	// initialize celery client
+	cli, _ := NewCeleryClient(
+		NewRedisCeleryBroker("redis://", "custom_queue"),
+		NewRedisCeleryBackend("redis://"),
+		5, // number of workers
+	)
+
+	// task
+	add := func(a, b int) int {
+		return a + b
+	}
+
+	// register task
+	cli.Register("add", add)
+
+	// start workers (non-blocking call)
+	cli.StartWorker()
+
+	// wait for client request
+	time.Sleep(10 * time.Second)
+
+	cli.SetBrokerQueue("another_queue")
+
+	// wait for client request
+	time.Sleep(10 * time.Second)
+
+	// stop workers gracefully (blocking call)
+	cli.StopWorker()
+
+}

--- a/gocelery.go
+++ b/gocelery.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const DefaultQueueName = "celery"
+
 // CeleryClient provides API for sending celery tasks
 type CeleryClient struct {
 	broker  CeleryBroker
@@ -21,6 +23,7 @@ type CeleryClient struct {
 type CeleryBroker interface {
 	SendCeleryMessage(*CeleryMessage) error
 	GetTaskMessage() (*TaskMessage, error) // must be non-blocking
+	SetBrokerQueue(string)
 }
 
 // CeleryBackend is interface for celery backend database
@@ -61,6 +64,11 @@ func (cc *CeleryClient) StopWorker() {
 // WaitForStopWorker waits for celery workers to terminate
 func (cc *CeleryClient) WaitForStopWorker() {
 	cc.worker.StopWait()
+}
+
+// SetBrokerQueue sets the queue of the broker to the specified one
+func (cc *CeleryClient) SetBrokerQueue(queue string) {
+	cc.broker.SetBrokerQueue(queue)
 }
 
 // Delay gets asynchronous result

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -17,10 +17,12 @@ import (
 const TIMEOUT = 2 * time.Second
 
 var (
-	redisBroker  = NewRedisCeleryBroker("redis://")
-	redisBackend = NewRedisCeleryBackend("redis://")
-	amqpBroker   = NewAMQPCeleryBroker("amqp://")
-	amqpBackend  = NewAMQPCeleryBackend("amqp://")
+	redisBroker      = NewRedisCeleryBroker("redis://")
+	redisBrokerQueue = NewRedisCeleryBroker("redis://", "custom_queue")
+	redisBackend     = NewRedisCeleryBackend("redis://")
+	amqpBroker       = NewAMQPCeleryBroker("amqp://")
+	amqpBrokerQueue  = NewAMQPCeleryBroker("amqp://", "custom_queue")
+	amqpBackend      = NewAMQPCeleryBackend("amqp://")
 )
 
 // TestInteger tests successful function execution
@@ -47,8 +49,28 @@ func TestInteger(t *testing.T) {
 			expected: 8953,
 		},
 		{
+			name:     "integer addition with redis broker on custom queue/backend",
+			broker:   redisBrokerQueue,
+			backend:  redisBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addInt,
+			inA:      2485,
+			inB:      6468,
+			expected: 8953,
+		},
+		{
 			name:     "integer addition with amqp broker/backend",
 			broker:   amqpBroker,
+			backend:  amqpBackend,
+			taskName: uuid.Must(uuid.NewV4()).String(),
+			taskFunc: addInt,
+			inA:      2485,
+			inB:      6468,
+			expected: 8953,
+		},
+		{
+			name:     "integer addition with amqp broker on custom queue/backend",
+			broker:   amqpBrokerQueue,
 			backend:  amqpBackend,
 			taskName: uuid.Must(uuid.NewV4()).String(),
 			taskFunc: addInt,


### PR DESCRIPTION
This PR is meant to be a followup on #44, I  tried to follow the comments in there. I tried to avoid changing api, and used the queue as an optional parameter for the broker creation functions.

This will likely conflict with #112, I assume we both try to answer our need, the route approach may be a better way, but it only covers AMQP. Feature-wise for the library I  think the ideal would be to have both:

- be able to specify a specific queue at broker creation
- be able to add route (which would replace my SetBrokerQueue())
- be able to del route
- they should work in both redis and amqp.

I'll also leave a comment on #112 and I hope we can work together to make something complete out of these.