### PR TITLE
Fix bug.  support for task execution without arguments

### DIFF
--- a/message.go
+++ b/message.go
@@ -168,6 +168,10 @@ func DecodeTaskMessage(encodedBody string) (*TaskMessage, error) {
 
 // Encode returns base64 json encoded string
 func (tm *TaskMessage) Encode() (string, error) {
+	if len(tm.Args) == 0 {
+		tm.Args = make([]interface{}, 0)
+	}
+
 	jsonData, err := json.Marshal(tm)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Now. can not execution no args tasks. 


``` task.py
@shared_task
def test_task():
    print("Hello, World!")
```

``` main.go
func main() {

        cli, _ := gocelery.NewCeleryClient(
                gocelery.NewRedisCeleryBroker(REDIS_URL),
                gocelery.NewRedisCeleryBackend(REDIS_URL),
                1,
        )

        asyncResult, err := cli.Delay(test_task)
        if err != nil {
                panic(err)
        }
```

`go run main.go`

```
[2019-06-26 17:37:44,256: ERROR/ForkPoolWorker-2] Task test_task[cd94a9db-cdec-43f4-be87-7474df4cca21] raised unexpected: TypeError('test_task object argument after * must be an iterable, not NoneType')
Traceback (most recent call last):
  File "/$HOME.local/share/virtualenvs/test-python-repo--NH_gJ4S/lib/python3.7/site-packages/celery/app/trace.py", line 385, in trace_task
    R = retval = fun(*args, **kwargs)
TypeError: test_task object argument after * must be an iterable, not NoneType
```

https://github.com/gocelery/gocelery/blob/master/message.go#L171
Add below code.
`fmt.Printf(stirng(jsonData))`

Debug log.
`{"id":"81af5e46-b6dc-46c3-9057-d21202d9c2aa","task":"vulns.tasks.test_task","args":null,"kwargs":{},"retries":0,"eta":null}`

args is null.
