### PR TITLE
Fix infinite loop bug in deliveryAck

### DIFF
--- a/amqp.go
+++ b/amqp.go
@@ -12,9 +12,8 @@ import (
 
 // deliveryAck acknowledges delivery message with retries on error
 func deliveryAck(delivery amqp.Delivery) {
-	retryCount := 3
 	var err error
-	for retryCount > 0 {
+	for retryCount := 3; retryCount > 0; retryCount-- {
 		if err = delivery.Ack(false); err == nil {
 			break
 		}

--- a/worker_test.go
+++ b/worker_test.go
@@ -156,7 +156,7 @@ func TestWorkerStartStop(t *testing.T) {
 		celeryWorker := NewCeleryWorker(tc.broker, tc.backend, 1000)
 		go celeryWorker.StartWorker()
 		time.Sleep(100 * time.Millisecond)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
 		go func() {
 			celeryWorker.StopWorker()
 			cancel()


### PR DESCRIPTION
Fix an infinite loop bug in https://github.com/gocelery/gocelery/issues/117
If RabbitMQ is down then deliveryAck will retry indefinitely and consume a lot of CPU resources.