### PR TITLE
Modify redis_broker.go GetCelryMessage BLPOP to BRPOP

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -48,7 +48,7 @@ func TestBrokerRedisSend(t *testing.T) {
 		}
 		conn := tc.broker.Get()
 		defer conn.Close()
-		messageJSON, err := conn.Do("BLPOP", tc.broker.queueName, "1")
+		messageJSON, err := conn.Do("BRPOP", tc.broker.queueName, "1")
 		if err != nil || messageJSON == nil {
 			t.Errorf("test '%s': failed to get celery message from broker: %v", tc.name, err)
 			releaseCeleryMessage(celeryMessage)

--- a/redis_broker.go
+++ b/redis_broker.go
@@ -64,7 +64,7 @@ func (cb *RedisCeleryBroker) SendCeleryMessage(message *CeleryMessage) error {
 func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 	conn := cb.Get()
 	defer conn.Close()
-	messageJSON, err := conn.Do("BLPOP", cb.queueName, "1")
+	messageJSON, err := conn.Do("BRPOP", cb.queueName, "1")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
https://github.com/gocelery/gocelery/issues/123
I think it has to be BRPOP