### PR TITLE
Limit maximum number of redis connections

### DIFF
--- a/redis_broker.go
+++ b/redis_broker.go
@@ -22,6 +22,7 @@ type RedisCeleryBroker struct {
 func NewRedisPool(uri string) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
+		MaxActive:   10,
 		IdleTimeout: 240 * time.Second,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.DialURL(uri)

--- a/redis_broker.go
+++ b/redis_broker.go
@@ -22,7 +22,7 @@ type RedisCeleryBroker struct {
 func NewRedisPool(uri string) *redis.Pool {
 	return &redis.Pool{
 		MaxIdle:     3,
-		MaxActive:   10,
+		MaxActive:   20,
 		IdleTimeout: 240 * time.Second,
 		Dial: func() (redis.Conn, error) {
 			c, err := redis.DialURL(uri)


### PR DESCRIPTION
Right now, there is no limit maximum connection to redis. We should keep this number small enough, otherwise, it will throw error when we set number of workers is large:
```
Err max number of clients reached
```
I set default maximum active connection to 20.