### PR TITLE
Fix hardcoded queue name in redis_broker

### DIFF
--- a/redis_broker.go
+++ b/redis_broker.go
@@ -64,7 +64,7 @@ func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 		return nil, fmt.Errorf("null message received from redis")
 	}
 	messageList := messageJSON.([]interface{})
-	if string(messageList[0].([]byte)) != "celery" {
+	if string(messageList[0].([]byte)) != cb.QueueName {
 		return nil, fmt.Errorf("not a celery message: %v", messageList[0])
 	}
 	var message CeleryMessage


### PR DESCRIPTION
Modified GetCeleryMessage under redis_broker to use queuename