### PR TITLE
add functions to set a custom queue name

### DIFF
--- a/broker_test.go
+++ b/broker_test.go
@@ -37,6 +37,10 @@ func TestBrokerRedisSend(t *testing.T) {
 			name:   "send task to redis broker with connection",
 			broker: redisBrokerWithConn,
 		},
+		{
+			name:   "send task to redis broker with queue name",
+			broker: redisBrokerWithQueue,
+		},
 	}
 	for _, tc := range testCases {
 		celeryMessage, err := makeCeleryMessage()
@@ -59,7 +63,7 @@ func TestBrokerRedisSend(t *testing.T) {
 			continue
 		}
 		messageList := messageJSON.([]interface{})
-		if string(messageList[0].([]byte)) != "celery" {
+		if string(messageList[0].([]byte)) != tc.broker.QueueName {
 			t.Errorf("test '%s': non celery message received", tc.name)
 			releaseCeleryMessage(celeryMessage)
 			continue
@@ -90,6 +94,10 @@ func TestBrokerRedisGet(t *testing.T) {
 		{
 			name:   "get task from redis broker with connection",
 			broker: redisBrokerWithConn,
+		},
+		{
+			name:   "send task to redis broker with queue name",
+			broker: redisBrokerWithQueue,
 		},
 	}
 	for _, tc := range testCases {
@@ -140,8 +148,16 @@ func TestBrokerSendGet(t *testing.T) {
 			broker: redisBrokerWithConn,
 		},
 		{
+			name:   "send task to redis broker with queue name",
+			broker: redisBrokerWithQueue,
+		},
+		{
 			name:   "send/get task for amqp broker",
 			broker: amqpBroker,
+		},
+		{
+			name:   "send/get task for amqp broker with queue name",
+			broker: amqpBrokerWithQueue,
 		},
 	}
 	for _, tc := range testCases {

--- a/gocelery.go
+++ b/gocelery.go
@@ -29,6 +29,8 @@ type CeleryBackend interface {
 	SetResult(taskID string, result *ResultMessage) error
 }
 
+const defaultQueueName = "celery"
+
 // NewCeleryClient creates new celery client
 func NewCeleryClient(broker CeleryBroker, backend CeleryBackend, numWorkers int) (*CeleryClient, error) {
 	return &CeleryClient{

--- a/gocelery_test.go
+++ b/gocelery_test.go
@@ -29,9 +29,11 @@ var (
 	}
 	redisBroker          = NewRedisCeleryBroker("redis://")
 	redisBrokerWithConn  = NewRedisBroker(redisPool)
+	redisBrokerWithQueue = NewRedisBrokerWithQueueName(redisPool, "test-queue")
 	redisBackend         = NewRedisCeleryBackend("redis://")
 	redisBackendWithConn = NewRedisBackend(redisPool)
 	amqpBroker           = NewAMQPCeleryBroker("amqp://")
+	amqpBrokerWithQueue  = NewAMQPCeleryBrokerWithQueueName("amqp://", "test-queue")
 	amqpBackend          = NewAMQPCeleryBackend("amqp://")
 )
 

--- a/redis_broker.go
+++ b/redis_broker.go
@@ -22,7 +22,15 @@ type RedisCeleryBroker struct {
 func NewRedisBroker(conn *redis.Pool) *RedisCeleryBroker {
 	return &RedisCeleryBroker{
 		Pool:      conn,
-		QueueName: "celery",
+		QueueName: defaultQueueName,
+	}
+}
+
+// NewRedisBrokerWithQueueName creates new RedisCeleryBroker with given redis connection pool and queue name
+func NewRedisBrokerWithQueueName(conn *redis.Pool, queueName string) *RedisCeleryBroker {
+	return &RedisCeleryBroker{
+		Pool:      conn,
+		QueueName: queueName,
 	}
 }
 
@@ -33,7 +41,7 @@ func NewRedisBroker(conn *redis.Pool) *RedisCeleryBroker {
 func NewRedisCeleryBroker(uri string) *RedisCeleryBroker {
 	return &RedisCeleryBroker{
 		Pool:      NewRedisPool(uri),
-		QueueName: "celery",
+		QueueName: defaultQueueName,
 	}
 }
 
@@ -64,7 +72,7 @@ func (cb *RedisCeleryBroker) GetCeleryMessage() (*CeleryMessage, error) {
 		return nil, fmt.Errorf("null message received from redis")
 	}
 	messageList := messageJSON.([]interface{})
-	if string(messageList[0].([]byte)) != "celery" {
+	if string(messageList[0].([]byte)) != cb.QueueName {
 		return nil, fmt.Errorf("not a celery message: %v", messageList[0])
 	}
 	var message CeleryMessage


### PR DESCRIPTION
This introduces new functions to customize queue name from default "celery" to own queue name for each redis and AMQP.
Related Issues: #43 , #136 