### PR TITLE
worker: release messages without defer

### DIFF
--- a/message.go
+++ b/message.go
@@ -216,6 +216,9 @@ func getReflectionResultMessage(val *reflect.Value) *ResultMessage {
 }
 
 func releaseResultMessage(v *ResultMessage) {
+	if v == nil {
+		return
+	}
 	v.reset()
 	resultMessagePool.Put(v)
 }

--- a/worker.go
+++ b/worker.go
@@ -60,16 +60,18 @@ func (w *CeleryWorker) StartWorkerWithContext(ctx context.Context) {
 					resultMsg, err := w.RunTask(taskMessage)
 					if err != nil {
 						log.Printf("failed to run task message %s: %+v", taskMessage.ID, err)
+						releaseResultMessage(resultMsg)
 						continue
 					}
-					defer releaseResultMessage(resultMsg)
 
 					// push result to backend
 					err = w.backend.SetResult(taskMessage.ID, resultMsg)
 					if err != nil {
 						log.Printf("failed to push result: %+v", err)
+						releaseResultMessage(resultMsg)
 						continue
 					}
+					releaseResultMessage(resultMsg)
 				}
 			}
 		}(i)


### PR DESCRIPTION
defer causes the function calls to occur at the termination of the
function, rather than at the end of the current block. This causes
defers within a loop to build up a large list of calls in memory and
doesn't run them until the worker terminates, causing a memory leak.

This also fixes a nil pointer dereference when the result is nil - for
example, if runTaskFunc's taskFunc.Call calls a worker function with no
return value.